### PR TITLE
Added tests for socks nukleus (in progress)

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.fallback.to.no.authentication/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.fallback.to.no.authentication/client.rpt
@@ -1,0 +1,35 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newClientAcceptRef ${nuklei:newReferenceId()} # external scope
+
+connect await ROUTED_CLIENT
+        "nukleus://socks/streams/source"
+  option nukleus:route ${newClientAcceptRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+
+# Client forward mode DOES NOT enforce target Nukleus to be TCP
+# Not expecting a TcpBeginExFW
+connected
+
+write "hello world"
+
+read "hello client"
+
+write "data flows as intended"
+
+read "data flows back as intended"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.fallback.to.no.authentication/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.fallback.to.no.authentication/server.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newClientAcceptRef ${nuklei:newReferenceId()}
+property newServerConnectRef ${newClientAcceptRef} # external scope
+
+property serverAccept "nukleus://target/streams/socks#source"
+
+# Build the TcpBeginExFW using hardcoded values
+property serverLocalAddress [0x7F 0x00 0x00 0x01]
+property serverLocalPort 60123
+property serverRemoteAddress [0x7F 0x00 0x00 0x01]
+property serverRemotePort 8080
+
+accept ${serverAccept}
+  option nukleus:route  ${newServerConnectRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+accepted
+
+# Server forward mode DOES enforce target Nukleus to be TCP by sending the TcpBeginExFW
+write nukleus:begin.ext ${socks:beginTcpExtensionIpv4(serverLocalAddress, serverLocalPort, serverRemoteAddress, serverRemotePort)}
+
+connected
+
+read "hello world"
+
+write "hello client"
+
+read "data flows as intended"
+
+write  "data flows back as intended"
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.request.with.command.not.supported/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.request.with.command.not.supported/client.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newClientAcceptRef ${nuklei:newReferenceId()} # external scope
+
+connect await ROUTED_CLIENT
+        "nukleus://socks/streams/source"
+  option nukleus:route ${newClientAcceptRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+
+# Client forward mode DOES NOT enforce target Nukleus to be TCP
+# Not expecting a TcpBeginExFW
+connected
+
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.request.with.command.not.supported/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.connect.request.with.command.not.supported/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newClientAcceptRef ${nuklei:newReferenceId()}
+property newServerConnectRef ${newClientAcceptRef} # external scope
+
+property serverAccept "nukleus://target/streams/socks#source"
+
+# Build the TcpBeginExFW using hardcoded values
+property serverLocalAddress [0x7F 0x00 0x00 0x01]
+property serverLocalPort 60123
+property serverRemoteAddress [0x7F 0x00 0x00 0x01]
+property serverRemotePort 8080
+
+accept ${serverAccept}
+  option nukleus:route  ${newServerConnectRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+accepted
+
+# Server forward mode DOES enforce target Nukleus to be TCP by sending the TcpBeginExFW
+write nukleus:begin.ext ${socks:beginTcpExtensionIpv4(serverLocalAddress, serverLocalPort, serverRemoteAddress, serverRemotePort)}
+
+connected
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.does.not.connect.no.acceptable.methods/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.does.not.connect.no.acceptable.methods/client.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newClientAcceptRef ${nuklei:newReferenceId()} # external scope
+
+connect await ROUTED_CLIENT
+        "nukleus://socks/streams/source"
+  option nukleus:route ${newClientAcceptRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+
+# Client forward mode DOES NOT enforce target Nukleus to be TCP
+# Not expecting a TcpBeginExFW
+connected
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.does.not.connect.no.acceptable.methods/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/socks/streams/forward/client.does.not.connect.no.acceptable.methods/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newClientAcceptRef ${nuklei:newReferenceId()}
+property newServerConnectRef ${newClientAcceptRef} # external scope
+
+property serverAccept "nukleus://target/streams/socks#source"
+
+# Build the TcpBeginExFW using hardcoded values
+property serverLocalAddress [0x7F 0x00 0x00 0x01]
+property serverLocalPort 60123
+property serverRemoteAddress [0x7F 0x00 0x00 0x01]
+property serverRemotePort 8080
+
+accept ${serverAccept}
+  option nukleus:route  ${newServerConnectRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+accepted
+
+# Server forward mode DOES enforce target Nukleus to be TCP by sending the TcpBeginExFW
+write nukleus:begin.ext ${socks:beginTcpExtensionIpv4(serverLocalAddress, serverLocalPort, serverRemoteAddress, serverRemotePort)}
+
+connected
+

--- a/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.fallback.to.no.authentication/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.fallback.to.no.authentication/client.rpt
@@ -22,10 +22,10 @@ connect await ROUTED_SERVER "nukleus://socks/streams/source"
   option nukleus:transmission "duplex"
 connected
 
-## Write the request bytes for connecting with no-authentication
+## Write the request bytes for connecting, no authentication required
 write [0x05]
 write [0x01]
-write [0x00] # no auth required
+write [0x02] # username & password
 
 ## Read the response, expect success
 read [0x05 0x00]

--- a/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.fallback.to.no.authentication/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.fallback.to.no.authentication/server.rpt
@@ -1,0 +1,61 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+
+property newServerAcceptRef ${nuklei:newReferenceId()}
+property newClientConnectRef ${newServerAcceptRef}
+
+property serverAccept "nukleus://socks/streams/source"
+
+accept ${serverAccept}
+  option nukleus:route ${newClientConnectRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+accepted
+connected
+
+## Read the request bytes for connecting, no authentication required
+read [0x05]
+read [0x01]
+read [0x02] # username & password
+
+## Write the response, expect success
+write [0x05 0x00]
+
+## Read CONNECT request
+read [0x05] # version: SOCKS v5
+read [0x01] # CONNECT command
+read [0x00] # RSV field
+read [0x03] # Address Type domain name
+read [0x0B] # Length of the FQDN
+read "example.com" # The FQDN
+read [0x1F 0x90]   # The destination port
+
+## Write CONNECT response
+write [0x05] # version: SOCKS v5
+write [0x00] # Succeeded
+write [0x00] # RSV field
+write [0x01] # Address Type domain name
+write [0x7F 0x00 0x00 0x01] # The Bound Server Address
+write [0xEA 0xDB]           # The Bound Server Port
+
+## Application data
+read "hello world"
+write "hello client"
+
+## Application data
+read "data flows as intended"
+write "data flows back as intended"

--- a/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.request.with.command.not.supported/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.request.with.command.not.supported/client.rpt
@@ -25,31 +25,26 @@ connected
 ## Write the request bytes for connecting with no-authentication
 write [0x05]
 write [0x01]
-write [0x00] # no auth required
+write [0x00]
 
 ## Read the response, expect success
 read [0x05 0x00]
 
 ## Write CONNECT request
 write [0x05] # version: SOCKS v5
-write [0x01] # CONNECT command
+write [0x04] # command not recognized
 write [0x00] # RSV field
 write [0x03] # Address Type domain name
 write [0x0B] # Length of the FQDN
 write "example.com" # The FQDN
 write [0x1F 0x90] # The destination port
 
+
 ## Read CONNECT response
 read [0x05] # version: SOCKS v5
-read [0x00] # Succeeded
+read [0x07] # command not supported
 read [0x00] # RSV field
+
 read [0x01] # Address Type domain name
-read [0x7F 0x00 0x00 0x01] # The Bound Server Address
-read [0xEA 0xDB]           # The Bound Server Port
-
-write "hello world"
-read "hello client"
-
-## Application data
-write "data flows as intended"
-read "data flows back as intended"
+read [0x7F 0x00 0x00 0x02] # The Bound Server Address
+read [0xEA 0xDC]           # The Bound Server Port (DB)

--- a/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.request.with.command.not.supported/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.connect.request.with.command.not.supported/server.rpt
@@ -1,0 +1,54 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+
+property newServerAcceptRef ${nuklei:newReferenceId()}
+property newClientConnectRef ${newServerAcceptRef}
+
+property serverAccept "nukleus://socks/streams/source"
+
+accept ${serverAccept}
+  option nukleus:route ${newClientConnectRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+accepted
+connected
+
+## Read the request bytes for connecting with no-authentication
+read [0x05 0x01 0x00]
+
+## Write the response, expect success
+write [0x05 0x00]
+
+## Read CONNECT request
+read [0x05] # version: SOCKS v5
+read [0x04] # command not recognized
+read [0x00] # RSV field
+read [0x03] # Address Type domain name
+read [0x0B] # Length of the FQDN
+read "example.com" # The FQDN
+read [0x1F 0x90]   # The destination port
+
+
+## Write CONNECT response
+write [0x05] # version: SOCKS v5
+write [0x07] # Command not supported
+write [0x00] # RSV field
+
+write [0x01] # Address Type domain name
+write [0x7F 0x00 0x00 0x02] # The Bound Server Address
+write [0xEA 0xDC]           # The Bound Server Port
+

--- a/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.does.not.connect.no.acceptable.methods/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.does.not.connect.no.acceptable.methods/client.rpt
@@ -22,34 +22,13 @@ connect await ROUTED_SERVER "nukleus://socks/streams/source"
   option nukleus:transmission "duplex"
 connected
 
-## Write the request bytes for connecting with no-authentication
+## Write the request bytes for connecting, no authentication required
 write [0x05]
 write [0x01]
-write [0x00] # no auth required
+write [0x00] # no auth
 
-## Read the response, expect success
-read [0x05 0x00]
+## Read the response, but no acceptable methods for authentication
+read [0x05 0xFF]
 
-## Write CONNECT request
-write [0x05] # version: SOCKS v5
-write [0x01] # CONNECT command
-write [0x00] # RSV field
-write [0x03] # Address Type domain name
-write [0x0B] # Length of the FQDN
-write "example.com" # The FQDN
-write [0x1F 0x90] # The destination port
-
-## Read CONNECT response
-read [0x05] # version: SOCKS v5
-read [0x00] # Succeeded
-read [0x00] # RSV field
-read [0x01] # Address Type domain name
-read [0x7F 0x00 0x00 0x01] # The Bound Server Address
-read [0xEA 0xDB]           # The Bound Server Port
-
-write "hello world"
-read "hello client"
-
-## Application data
-write "data flows as intended"
-read "data flows back as intended"
+## Client closes connection
+write close

--- a/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.does.not.connect.no.acceptable.methods/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/socks/rfc1928/forward/client.does.not.connect.no.acceptable.methods/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+
+property newServerAcceptRef ${nuklei:newReferenceId()}
+property newClientConnectRef ${newServerAcceptRef}
+
+property serverAccept "nukleus://socks/streams/source"
+
+accept ${serverAccept}
+  option nukleus:route ${newClientConnectRef}
+  option nukleus:window 65536
+  option nukleus:transmission "duplex"
+accepted
+connected
+
+## Read the request bytes for connecting, no authentication required
+read [0x05]
+read [0x01]
+read [0x00] # no auth
+
+## Write the response, but no acceptable methods for authentication
+write [0x05 0xFF]
+
+read closed

--- a/src/test/java/org/reaktivity/specification/nukleus/socks/control/ControlIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/socks/control/ControlIT.java
@@ -59,7 +59,7 @@ public class ControlIT
     }
 
     @Test
-    @ScriptProperty("mode 'REVERSE'")
+    @ScriptProperty("mode 'REVERSE'") //FORWARD??
     @Specification({
         "route/client/nukleus",
         "route/client/controller"

--- a/src/test/java/org/reaktivity/specification/nukleus/socks/stream/forward/NukleusIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/socks/stream/forward/NukleusIT.java
@@ -48,4 +48,41 @@ public class NukleusIT
         k3po.notifyBarrier("ROUTED_CLIENT");
         k3po.finish();
     }
+
+    @Test
+    @ScriptProperty("serverAccept \"nukleus://socks/streams/source\"")
+    @Specification({
+        "${scripts}/client.does.not.connect.no.acceptable.methods/client",
+        "${scripts}/client.does.not.connect.no.acceptable.methods/server"})
+    public void shouldNotEstablishConnectionNoAcceptableMethods() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @ScriptProperty("serverAccept \"nukleus://socks/streams/source\"")
+    @Specification({
+        "${scripts}/client.connect.fallback.to.no.authentication/client",
+        "${scripts}/client.connect.fallback.to.no.authentication/server"})
+    public void shouldEstablishConnectionFallbackToNoAuthentication() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
+    @Test
+    @ScriptProperty("serverAccept \"nukleus://socks/streams/source\"")
+    @Specification({
+        "${scripts}/client.connect.request.with.command.not.supported/client",
+        "${scripts}/client.connect.request.with.command.not.supported/server"})
+    public void shouldNotEstablishConnectionCommandNotSupported() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_CLIENT");
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/specification/socks/rfc1928/forward/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/specification/socks/rfc1928/forward/ConnectionIT.java
@@ -46,4 +46,37 @@ public class ConnectionIT
         k3po.notifyBarrier("ROUTED_SERVER");
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${scripts}/client.does.not.connect.no.acceptable.methods/client",
+        "${scripts}/client.does.not.connect.no.acceptable.methods/server"})
+    public void shouldNotEstablishConnectionNoAcceptableMethods() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/client.connect.fallback.to.no.authentication/client",
+        "${scripts}/client.connect.fallback.to.no.authentication/server"})
+    public void shouldEstablishConnectionFallbackToNoAuthentication() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${scripts}/client.connect.request.with.command.not.supported/client",
+        "${scripts}/client.connect.request.with.command.not.supported/server"})
+    public void shouldNotEstablishConnectionCommandNotSupported() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
Added tests for the following scenarios:
- the server doesn't accept any of the methods listed by the client, so the client closes the connection (ConnectionIT.shouldNotEstablishConnectionNoAcceptableMethods)
- client sends in the request username&password as authentication method, but no authentication method will be used instead (ConnectionIT.shouldEstablishConnectionFallbackToNoAuthentication)
- client sends in the request a command that is not recognized, the server replies accordingly (ConnectionIT.shouldNotEstablishConnectionCommandNotSupported)